### PR TITLE
Remove Legitimate Site from blacklist to whitelist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -19,6 +19,7 @@
     "originprotocol.com"
   ],
   "whitelist": [
+    "bnbminer.finance",
     "dubaibornapes.com",
     "elrondwildwest.net",
     "dictus.dk",
@@ -1534,7 +1535,6 @@
     "ape-swap.com",
     "bakedbeans.io",
     "bevee-club.mint-site.live",
-    "bnbminer.finance",
     "cryptobots-gamme.xyz",
     "dbp.coinsbase8.com",
     "dcex-exchange.com",


### PR DESCRIPTION
bnbminer.finance - #8850

Also fixes: #8849 #8854 #8857 #8877 #8891 #8920 #8926 #8942 #8951 #8952 #8957 #8958 #8959 #8963 #8970 and so on.